### PR TITLE
Added autocomplete attribute for one-time-codes

### DIFF
--- a/src/resources/views/form.blade.php
+++ b/src/resources/views/form.blade.php
@@ -15,7 +15,7 @@
                             <label for="token" class="col-md-4 col-form-label text-md-right">@lang('twofactor-auth::twofactor-auth.label')</label>
 
                             <div class="col-md-6">
-                                <input id="token" type="text" class="form-control{{ $errors->has('token') ? ' is-invalid' : '' }}" name="token" value="{{ old('token') }}" required autofocus>
+                                <input id="token" type="text" autocomplete="one-time-code" class="form-control{{ $errors->has('token') ? ' is-invalid' : '' }}" name="token" value="{{ old('token') }}" required autofocus>
 
                                 @if ($errors->has('token'))
                                     <span class="invalid-feedback" role="alert">


### PR DESCRIPTION
Added an autocomplete attribute that makes the UX slicker for iOS and Android users. When a 2FA sms is sent it'll automatically suggest filling in the input with the value of the code in the message.